### PR TITLE
Add termination protection var

### DIFF
--- a/modules/guac/README.md
+++ b/modules/guac/README.md
@@ -6,11 +6,11 @@ Terraform module that deploys Apache Guacamole.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| AmiId | (Optional) AMI ID -- will supersede Lambda-based AMI lookup using AmiNameSearchString | string | `""` | no |
+| AmiId | \(Optional\) AMI ID -- will supersede Lambda-based AMI lookup using AmiNameSearchString | string | `""` | no |
 | AmiNameSearchString | Search pattern to match against an AMI Name | string | `"amzn-ami-hvm-2018.03.*-x86_64-gp2"` | no |
 | BrandText | Text/Label to display branding for the Guac Login page | string | `"Remote Access"` | no |
 | Capabilities | Required IAM capabilities | list(string) | `<list>` | no |
-| CloudWatchAgentUrl | (Optional) S3 URL to CloudWatch Agent installer. Example: s3://amazoncloudwatch-agent/windows/amd64/latest/amazon-cloudwatch-agent.msi | string | `"s3://amazoncloudwatch-agent/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm"` | no |
+| CloudWatchAgentUrl | \(Optional\) S3 URL to CloudWatch Agent installer. Example: s3://amazoncloudwatch-agent/windows/amd64/latest/amazon-cloudwatch-agent.msi | string | `"s3://amazoncloudwatch-agent/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm"` | no |
 | DesiredCapacity | The number of instances the autoscale group will spin up initially | string | `"1"` | no |
 | DisableRollback | Set to true to disable rollback of the stack if stack creation failed. Conflicts with OnFailure | string | `"false"` | no |
 | ElbZones | Map of ELB Zones | map(string) | `<map>` | no |
@@ -23,20 +23,20 @@ Terraform module that deploys Apache Guacamole.
 | IamRoleArn | The ARN of an IAM role that AWS CloudFormation assumes to create the stack. If you don't specify a value, AWS CloudFormation uses the role that was previously associated with the stack. If no role is available, AWS CloudFormation uses a temporary session that is generated from your user credentials | string | `""` | no |
 | InstanceType | Amazon EC2 instance type for the Remote Desktop Session Instance | string | `"c5.large"` | no |
 | KeyPairName | Public/private key pairs allow you to securely connect to your instance after it launches | string | `""` | no |
-| LdapDN | Distinguished Name (DN) of the LDAP directory.  E.g. DC=domain,DC=com | string | n/a | yes |
+| LdapDN | Distinguished Name \(DN\) of the LDAP directory.  E.g. DC=domain,DC=com | string | n/a | yes |
 | LdapServer | Name of LDAP server Guacamole will authenticate against.  E.g. domain.com | string | n/a | yes |
 | MaxCapacity | The maximum number of instances for the autoscale group | string | `"1"` | no |
 | MinCapacity | The minimum number of instances for the autoscale group | string | `"0"` | no |
 | NotificationArns | A list of SNS topic ARNs to publish stack related events | list(string) | `<list>` | no |
-| OnFailureAction | Action to be taken if stack creation fails. This must be one of: DO_NOTHING, ROLLBACK, or DELETE. Conflicts with DisableRollback | string | `"ROLLBACK"` | no |
+| OnFailureAction | Action to be taken if stack creation fails. This must be one of: DO\_NOTHING, ROLLBACK, or DELETE. Conflicts with DisableRollback | string | `"ROLLBACK"` | no |
 | PolicyBody | String containing the stack policy body. Conflicts with PolicyUrl | string | `""` | no |
 | PolicyUrl | URL to a file containing the stack policy. Conflicts with PolicyBody | string | `""` | no |
 | PrivateSubnetIds | List of Private Subnet IDs where the Guacamole instances will run | list(string) | n/a | yes |
 | PublicSubnetIds | List of Public subnet IDs to attach to the Application Load Balancer | list(string) | n/a | yes |
-| ScaleDownDesiredCapacity | (Optional) Desired number of instances during the Scale Down Scheduled Action; ignored if ScaleDownSchedule is unset | string | `"1"` | no |
-| ScaleDownSchedule | (Optional) Scheduled Action in cron-format (UTC) to scale down the number of instances; ignored if empty or ScaleUpSchedule is unset (E.g. '0 0 * * *') | string | `""` | no |
-| ScaleUpSchedule | (Optional) Scheduled Action in cron-format (UTC) to scale up to the Desired Capacity; ignored if empty or ScaleDownSchedule is unset (E.g. '0 10 * * Mon-Fri') | string | `""` | no |
-| SslCertificateName | The name (for IAM) or identifier (for ACM) of the SSL certificate to associate with the ALB -- the cert must already exist in the service | string | n/a | yes |
+| ScaleDownDesiredCapacity | \(Optional\) Desired number of instances during the Scale Down Scheduled Action; ignored if ScaleDownSchedule is unset | string | `"1"` | no |
+| ScaleDownSchedule | \(Optional\) Scheduled Action in cron-format \(UTC\) to scale down the number of instances; ignored if empty or ScaleUpSchedule is unset \(E.g. '0 0 \* \* \*'\) | string | `""` | no |
+| ScaleUpSchedule | \(Optional\) Scheduled Action in cron-format \(UTC\) to scale up to the Desired Capacity; ignored if empty or ScaleDownSchedule is unset \(E.g. '0 10 \* \* Mon-Fri'\) | string | `""` | no |
+| SslCertificateName | The name \(for IAM\) or identifier \(for ACM\) of the SSL certificate to associate with the ALB -- the cert must already exist in the service | string | n/a | yes |
 | SslCertificateService | The service hosting the SSL certificate | string | `"ACM"` | no |
 | StackCreateTimeout | The amount of time in minutes before the stack create fails | string | `"20"` | no |
 | StackDeleteTimeout | The amount of time in minutes before the stack delete fails | string | `"20"` | no |
@@ -47,6 +47,6 @@ Terraform module that deploys Apache Guacamole.
 | URL2 | Second custom URL/link to display on the Guac Login page | string | `"https://redmine.domain.com"` | no |
 | URLText1 | Text/Label to display for the First custom URL/link displayed on the Guac Login page | string | `"Account Services"` | no |
 | URLText2 | Text/Label to display for the Second custom URL/link displayed on the Guac Login page | string | `"Redmine"` | no |
-| UpdateSchedule | (Optional) Time interval between auto stack updates. Refer to the AWS documentation for valid input syntax: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html | string | `"cron(0 5 ? * Sun *)"` | no |
-| VpcId | VPC to deploy instance(s) into | string | n/a | yes |
+| UpdateSchedule | \(Optional\) Time interval between auto stack updates. Refer to the AWS documentation for valid input syntax: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html | string | `"cron(0 5 ? * Sun *)"` | no |
+| VpcId | VPC to deploy instance\(s\) into | string | n/a | yes |
 

--- a/modules/rdcb/README.md
+++ b/modules/rdcb/README.md
@@ -6,32 +6,32 @@ Terraform module that deploys a Remote Desktop Connection Broker/File Server.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| AmiId | (Optional) AMI ID -- will supersede Lambda-based AMI lookup using AmiNameSearchString | string | `""` | no |
+| AmiId | \(Optional\) AMI ID -- will supersede Lambda-based AMI lookup using AmiNameSearchString | string | `""` | no |
 | AmiNameSearchString | Search pattern to match against an AMI Name | string | `"Windows_Server-2016-English-Full-Base-*"` | no |
-| CloudWatchAgentUrl | (Optional) HTTPS URL to CloudWatch Agent installer. Example: https://s3.amazonaws.com/amazoncloudwatch-agent/windows/amd64/latest/amazon-cloudwatch-agent.msi | string | `""` | no |
+| CloudWatchAgentUrl | \(Optional\) HTTPS URL to CloudWatch Agent installer. Example: https://s3.amazonaws.com/amazoncloudwatch-agent/windows/amd64/latest/amazon-cloudwatch-agent.msi | string | `""` | no |
 | DataVolumeSize | Size of the data volume to attach to the instance | string | `"50"` | no |
-| DataVolumeSnapshotId | (Optional) Snapshot ID of an existing EBS volume. Leave blank to instantiate an empty volume | string | `""` | no |
+| DataVolumeSnapshotId | \(Optional\) Snapshot ID of an existing EBS volume. Leave blank to instantiate an empty volume | string | `""` | no |
 | DomainAccessUserGroup | Domain group of users authorized to use the remote access solution | string | `"yourgroupname"` | no |
 | DomainDirectoryId | ID of the AWS Directory Service domain, e.g. d-xxxxxxxxxx | string | `"d-xxxxxxxxxx"` | no |
-| DomainDnsName | Fully qualified domain name (FQDN) of the forest root domain, e.g. example.com | string | `"ad.example.com"` | no |
-| DomainNetbiosName | NetBIOS name of the domain (e.g. EXAMPLE) | string | `"example"` | no |
+| DomainDnsName | Fully qualified domain name \(FQDN\) of the forest root domain, e.g. example.com | string | `"ad.example.com"` | no |
+| DomainNetbiosName | NetBIOS name of the domain \(e.g. EXAMPLE\) | string | `"example"` | no |
 | Ec2SubnetAz | Availability zone of the private subnet | string | `"us-east-1a"` | no |
 | Ec2SubnetId | Private Subnet ID where the file server will run | string | `"subnet-xxxxxxxx"` | no |
 | ExtraSecurityGroupIds | List of extra Security Group IDs to attach to the RDCB EC2 instance | list(string) | `<list>` | no |
 | ForceCfnInitUpdate | Toggles a cfn-init metadata update even if nothing else changes | string | `"A"` | no |
 | InstanceType | Amazon EC2 instance type for the Remote Desktop Session Instance | string | `"t2.medium"` | no |
 | KeyPairName | Public/private key pairs allow you to securely connect to your instance after it launches | string | `"yourkeypair"` | no |
-| NoPublicIp | Controls whether to assign the instances a public IP. Recommended to leave at 'true' _unless_ launching in a public subnet | string | `"true"` | no |
-| NotificationEmail | (Optional) Email address to subscribe to notifications and alarms | string | `""` | no |
+| NoPublicIp | Controls whether to assign the instances a public IP. Recommended to leave at 'true' \_unless\_ launching in a public subnet | string | `"true"` | no |
+| NotificationEmail | \(Optional\) Email address to subscribe to notifications and alarms | string | `""` | no |
 | PatchSchedule | Schedule used to apply patches to the instance | string | `"cron(0 6 ? * Sat *)"` | no |
 | PatchSnsTopicArn | SNS Topic used for patch status notifications | string | `""` | no |
 | RdcbDnszoneId | Zone to create DNS record for RDCB instance | string | `""` | no |
 | RepoBranchPrefixUrl | URL prefix where the repo scripts can be retrieved | string | `"https://raw.githubusercontent.com/plus3it/cfn/master"` | no |
 | S3Bucket |  | string | n/a | yes |
 | SecurityGroupIngress | List of security group IPs to allow | list(string) | `<list>` | no |
-| SnapshotFrequency | (Optional) Specify an interval in minutes to configure snapshots of the EBS fileshare volume. Set an empty value "" to skip configuring snapshots. Default interval is 60 minutes. | string | `"60"` | no |
+| SnapshotFrequency | \(Optional\) Specify an interval in minutes to configure snapshots of the EBS fileshare volume. Set an empty value "" to skip configuring snapshots. Default interval is 60 minutes. | string | `"60"` | no |
 | SsmKeyId | KMS Key ID used to encrypt/decrypt the SsmRdcbCredential | string | `"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"` | no |
-| SsmRdcbCredential | SSM Parameter Name for a SecureString containing the domain credential for the RDCB service account. SSM Parameter Value format is '@{Username = "<user>"; Password = "<password>"}' | string | `"/your-path/rdcb/credential"` | no |
+| SsmRdcbCredential | SSM Parameter Name for a SecureString containing the domain credential for the RDCB service account. SSM Parameter Value format is '@\{Username = "<user>"; Password = "<password>"\}' | string | `"/your-path/rdcb/credential"` | no |
 | StackName | CloudFormation Stack Name.  Must be less than 10 characters | string | n/a | yes |
 | TerminationProtection | Enable or disable instance termination protection.  Protection is enabled by default. | string | `"true"` | no |
 | VpcId | VPC to deploy instance into | string | `"vpc-12345678"` | no |

--- a/modules/rdcb/README.md
+++ b/modules/rdcb/README.md
@@ -33,6 +33,7 @@ Terraform module that deploys a Remote Desktop Connection Broker/File Server.
 | SsmKeyId | KMS Key ID used to encrypt/decrypt the SsmRdcbCredential | string | `"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"` | no |
 | SsmRdcbCredential | SSM Parameter Name for a SecureString containing the domain credential for the RDCB service account. SSM Parameter Value format is '@{Username = "<user>"; Password = "<password>"}' | string | `"/your-path/rdcb/credential"` | no |
 | StackName | CloudFormation Stack Name.  Must be less than 10 characters | string | n/a | yes |
+| TerminationProtection | Enable or disable instance termination protection.  Protection is enabled by default. | string | `"true"` | no |
 | VpcId | VPC to deploy instance into | string | `"vpc-12345678"` | no |
 
 ## Outputs

--- a/modules/rdcb/main.tf
+++ b/modules/rdcb/main.tf
@@ -135,6 +135,7 @@ locals {
     "\"SnapshotFrequency=${var.SnapshotFrequency}\"",
     "\"SsmKeyId=${var.SsmKeyId}\"",
     "\"SsmRdcbCredential=${var.SsmRdcbCredential}\"",
+    "\"TerminationProtection=${var.TerminationProtection}\"",
     "\"VpcId=${var.VpcId}\"",
     "--capabilities CAPABILITY_IAM",
   ]

--- a/modules/rdcb/ra_rdcb_fileserver_standalone.template.cfn.yaml
+++ b/modules/rdcb/ra_rdcb_fileserver_standalone.template.cfn.yaml
@@ -228,6 +228,13 @@ Parameters:
     MaxLength: '1024'
     MinLength: '1'
     Type: String
+  TerminationProtection:
+    AllowedValues:
+      - 'false'
+      - 'true'
+    Default: 'true'
+    Description: Enable or disable instance termination protection.  Protection is enabled by default.
+    Type: String
   VpcId:
     Description: VPC ID
     Type: AWS::EC2::VPC::Id
@@ -790,7 +797,7 @@ Resources:
             DeleteOnTermination: true
             VolumeSize: 50
             VolumeType: gp2
-      DisableApiTermination: true
+      DisableApiTermination: !Ref TerminationProtection
       EbsOptimized: !FindInMap [InstanceTypeMap, !Ref InstanceType, SupportsEbsOptimized]
       IamInstanceProfile: !Ref Ec2IamInstanceProfile
       ImageId: !If [UseAmiLookup, !Sub '${AmiIdLookup.Id}', !Ref AmiId]

--- a/modules/rdcb/variables.tf
+++ b/modules/rdcb/variables.tf
@@ -156,6 +156,12 @@ variable "StackName" {
   type        = string
 }
 
+variable "TerminationProtection" {
+  default     = true
+  description = "Enable or disable instance termination protection.  Protection is enabled by default."
+  type        = string
+}
+
 variable "VpcId" {
   default     = "vpc-12345678"
   description = "VPC to deploy instance into"

--- a/modules/rdgw/README.md
+++ b/modules/rdgw/README.md
@@ -6,15 +6,15 @@ Terraform module that deploys a Remote Desktop Gateway.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| AmiId | (Optional) AMI ID -- will supersede Lambda-based AMI lookup using AmiNameSearchString | string | `""` | no |
+| AmiId | \(Optional\) AMI ID -- will supersede Lambda-based AMI lookup using AmiNameSearchString | string | `""` | no |
 | AmiNameSearchString | Search pattern to match against an AMI Name | string | `"Windows_Server-2016-English-Full-Base-*"` | no |
 | AuthenticationMethod | Configures the RDGW for either Password or Smartcard authentication | string | `"Password"` | no |
-| CloudWatchAgentUrl | (Optional) S3 URL to CloudWatch Agent MSI. Example: s3://amazoncloudwatch-agent/windows/amd64/latest/amazon-cloudwatch-agent.msi | string | `""` | no |
+| CloudWatchAgentUrl | \(Optional\) S3 URL to CloudWatch Agent MSI. Example: s3://amazoncloudwatch-agent/windows/amd64/latest/amazon-cloudwatch-agent.msi | string | `""` | no |
 | DesiredCapacity | The number of instances the autoscale group will spin up initially | string | `"1"` | no |
 | DnsName | Hostname of A record created | string | `""` | no |
 | DomainDirectoryId | ID of the AWS Directory Service domain, e.g. d-xxxxxxxxxx | string | n/a | yes |
-| DomainDnsName | Fully qualified domain name (FQDN) of the forest root domain e.g. example.com | string | `"example.com"` | no |
-| DomainNetbiosName | NetBIOS name of the domain (e.g. EXAMPLE) | string | `"EXAMPLE"` | no |
+| DomainDnsName | Fully qualified domain name \(FQDN\) of the forest root domain e.g. example.com | string | `"example.com"` | no |
+| DomainNetbiosName | NetBIOS name of the domain \(e.g. EXAMPLE\) | string | `"EXAMPLE"` | no |
 | ForceUpdateToggle | A/B toggle that forces a change to a LaunchConfig property, triggering the AutoScale Update Policy | string | `"A"` | no |
 | InstanceType | Amazon EC2 instance type for the Remote Desktop Gateway Instance | string | `"t2.micro"` | no |
 | KeyPairName | Public/private key pairs allow you to securely connect to your instance after it launches | string | `""` | no |
@@ -26,13 +26,13 @@ Terraform module that deploys a Remote Desktop Gateway.
 | RemoteAccessUserGroup | Domain group of users authorized to use the RDGW | string | `"Domain Admins"` | no |
 | RepoBranchPrefixUrl | URL prefix where the repo scripts can be retrieved | string | `"https://raw.githubusercontent.com/plus3it/cfn/master"` | no |
 | S3Bucket |  | string | n/a | yes |
-| ScaleDownDesiredCapacity | (Optional) Desired number of instances during the Scale Down Scheduled Action; ignored if ScaleDownSchedule is unset | string | `"1"` | no |
-| ScaleDownSchedule | (Optional) Scheduled Action in cron-format (UTC) to scale down the number of instances; ignored if empty or ScaleUpSchedule is unset (E.g. "0 0 * * *") | string | `""` | no |
-| ScaleUpSchedule | (Optional) Scheduled Action in cron-format (UTC) to scale up to the Desired Capacity; ignored if empty or ScaleDownSchedule is unset (E.g. "0 10 * * Mon-Fri") | string | `""` | no |
-| SslCertificateName | The name (for IAM) or identifier (for ACM) of the SSL certificate to associate with the LB -- the cert must already exist in the service | string | `""` | no |
+| ScaleDownDesiredCapacity | \(Optional\) Desired number of instances during the Scale Down Scheduled Action; ignored if ScaleDownSchedule is unset | string | `"1"` | no |
+| ScaleDownSchedule | \(Optional\) Scheduled Action in cron-format \(UTC\) to scale down the number of instances; ignored if empty or ScaleUpSchedule is unset \(E.g. "0 0 \* \* \*"\) | string | `""` | no |
+| ScaleUpSchedule | \(Optional\) Scheduled Action in cron-format \(UTC\) to scale up to the Desired Capacity; ignored if empty or ScaleDownSchedule is unset \(E.g. "0 10 \* \* Mon-Fri"\) | string | `""` | no |
+| SslCertificateName | The name \(for IAM\) or identifier \(for ACM\) of the SSL certificate to associate with the LB -- the cert must already exist in the service | string | `""` | no |
 | SslCertificateService | The service hosting the SSL certificate.  ACM or IAM are allowed values | string | `"ACM"` | no |
 | StackName | CloudFormation Stack Name.  Must be less than 10 characters | string | n/a | yes |
-| UpdateSchedule | (Optional) Time interval between auto stack updates. Refer to the AWS documentation for valid input syntax: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html | string | `""` | no |
+| UpdateSchedule | \(Optional\) Time interval between auto stack updates. Refer to the AWS documentation for valid input syntax: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html | string | `""` | no |
 | VpcId | VPC to deploy instance into | string | `"vpc-12345678"` | no |
 
 ## Outputs

--- a/modules/rdsh/README.md
+++ b/modules/rdsh/README.md
@@ -6,19 +6,19 @@ Terraform module that deploys Remote Desktop Sessions Hosts.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| AmiId | (Optional) AMI ID -- will supersede Lambda-based AMI lookup using AmiNameSearchString | string | `""` | no |
+| AmiId | \(Optional\) AMI ID -- will supersede Lambda-based AMI lookup using AmiNameSearchString | string | `""` | no |
 | AmiNameSearchString | Search pattern to match against an AMI Name | string | `"Windows_Server-2016-English-Full-Base-*"` | no |
-| CloudWatchAgentUrl | (Optional) S3 URL to CloudWatch Agent MSI. Example: s3://amazoncloudwatch-agent/windows/amd64/latest/amazon-cloudwatch-agent.msi | string | `""` | no |
-| ConnectionBrokerFqdn | Fully qualified domain name (FQDN) of the primary Connection Broker, e.g. 'cb.example.com' | string | `""` | no |
+| CloudWatchAgentUrl | \(Optional\) S3 URL to CloudWatch Agent MSI. Example: s3://amazoncloudwatch-agent/windows/amd64/latest/amazon-cloudwatch-agent.msi | string | `""` | no |
+| ConnectionBrokerFqdn | Fully qualified domain name \(FQDN\) of the primary Connection Broker, e.g. 'cb.example.com' | string | `""` | no |
 | DesiredCapacity | The number of instances the autoscale group will spin up initially | string | `"1"` | no |
 | DnsName | Name of Host A DNS Record | string | `""` | no |
 | DomainAccessUserGroup | Domain group of users authorized to use the RDSH | string | `"Domain Users"` | no |
 | DomainDirectoryId | ID of the AWS Directory Service domain, e.g. d-xxxxxxxxxx | string | `""` | no |
-| DomainDnsName | Fully qualified domain name (FQDN) of the forest root domain e.g. example.com | string | `"example.com"` | no |
-| DomainNetbiosName | Netbios name of the domain (e.g. EXAMPLE) | string | `"EXAMPLE"` | no |
+| DomainDnsName | Fully qualified domain name \(FQDN\) of the forest root domain e.g. example.com | string | `"example.com"` | no |
+| DomainNetbiosName | Netbios name of the domain \(e.g. EXAMPLE\) | string | `"EXAMPLE"` | no |
 | DomainSvcAccount | User name for the account that will join the instance to the Connection Broker Cluster | string | n/a | yes |
 | DomainSvcPassword | Password for the Connection Broker service account. Must be at least 8 characters containing letters, numbers and symbols | string | n/a | yes |
-| ExtraSecurityGroupIds | Comma separated string of extra Security Group IDs to attach to the RDSH instances -- include _at least_ the SG allowing connectivity to the Connection Broker database | list(string) | `<list>` | no |
+| ExtraSecurityGroupIds | Comma separated string of extra Security Group IDs to attach to the RDSH instances -- include \_at least\_ the SG allowing connectivity to the Connection Broker database | list(string) | `<list>` | no |
 | ForceUpdateToggle | A/B toggle that forces a change to a LaunchConfig property, triggering the AutoScale Update Policy | string | `"A"` | no |
 | InstanceType | Amazon EC2 instance type for the Remote Desktop Session Instance | string | `"t2.medium"` | no |
 | KeyPairName | Public/private key pairs allow you to securely connect to your instance after it launches | string | `""` | no |
@@ -32,12 +32,12 @@ Terraform module that deploys Remote Desktop Sessions Hosts.
 | RdpPrivateKeyS3Endpoint | S3 endpoint URL hosting the bucket where the RDP certificate private key is stored | string | `"https://s3.amazonaws.com"` | no |
 | RepoBranchPrefixUrl | URL prefix where the repo scripts can be retrieved | string | `"https://raw.githubusercontent.com/plus3it/cfn/master"` | no |
 | S3Bucket |  | string | `"your_bucket"` | no |
-| ScaleDownDesiredCapacity | (Optional) Desired number of instances during the Scale Down Scheduled Action; ignored if ScaleDownSchedule is unset | string | `"1"` | no |
-| ScaleDownSchedule | (Optional) Scheduled Action in cron-format (UTC) to scale down the number of instances; ignored if empty or ScaleUpSchedule is unset (E.g. '0 0 * * *') | string | `""` | no |
-| ScaleUpSchedule | (Optional) Scheduled Action in cron-format (UTC) to scale up to the Desired Capacity; ignored if empty or ScaleDownSchedule is unset (E.g. '0 10 * * Mon-Fri') | string | `""` | no |
+| ScaleDownDesiredCapacity | \(Optional\) Desired number of instances during the Scale Down Scheduled Action; ignored if ScaleDownSchedule is unset | string | `"1"` | no |
+| ScaleDownSchedule | \(Optional\) Scheduled Action in cron-format \(UTC\) to scale down the number of instances; ignored if empty or ScaleUpSchedule is unset \(E.g. '0 0 \* \* \*'\) | string | `""` | no |
+| ScaleUpSchedule | \(Optional\) Scheduled Action in cron-format \(UTC\) to scale up to the Desired Capacity; ignored if empty or ScaleDownSchedule is unset \(E.g. '0 10 \* \* Mon-Fri'\) | string | `""` | no |
 | StackName | CloudFormation Stack Name.  Must be less than 10 characters | string | n/a | yes |
 | SubnetIDs | List of Subnet IDs where the RDSH instances and ELB will be launched | list(string) | `<list>` | no |
-| UpdateSchedule | (Optional) Time interval between auto stack updates. Refer to the AWS documentation for valid input syntax: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html | string | `""` | no |
+| UpdateSchedule | \(Optional\) Time interval between auto stack updates. Refer to the AWS documentation for valid input syntax: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html | string | `""` | no |
 | UserProfileDiskPath | Path to a CIFS share where User Profile Disks are stored, e.g. "\\home.example.com\Profiles$" | string | `"\\\\\\home.example.com\\Profile$"` | no |
-| VpcId | VPC to deploy instance(s) into | string | n/a | yes |
+| VpcId | VPC to deploy instance\(s\) into | string | n/a | yes |
 

--- a/tests/example_testcase/main.tf
+++ b/tests/example_testcase/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version  = "~> 0.12.0"
+  required_version = "~> 0.12.0"
 }
 
 module "example" {


### PR DESCRIPTION
Additional documentation formatting was required due to a newer version of terraform-docs being used for linting.