### PR TITLE
Corrects overeager policy de-scoping...

### DIFF
--- a/modules/rdgw/ra_rdgw_autoscale_public_lb.template.cfn.yaml
+++ b/modules/rdgw/ra_rdgw_autoscale_public_lb.template.cfn.yaml
@@ -370,10 +370,6 @@ Resources:
               - s3:ListBucket
             Effect: Allow
             Resource: arn:aws:s3:::amazon-ssm-packages-*
-          - Action:
-              - autoscaling:DescribeAutoScalingInstances
-            Effect: Allow
-            Resource: '*'
         Version: 2012-10-17
       PolicyName: !Sub ra-rdgw-${AWS::StackName}
       Roles:

--- a/modules/rdsh/ra_rdsh_autoscale_internal_lb.template.cfn.yaml
+++ b/modules/rdsh/ra_rdsh_autoscale_internal_lb.template.cfn.yaml
@@ -404,6 +404,17 @@ Resources:
               - s3:ListBucket
             Effect: Allow
             Resource: arn:aws:s3:::amazon-ssm-packages-*
+          - Action:
+              - autoscaling:DescribeAutoScalingInstances
+            Effect: Allow
+            Resource: '*'
+          - Action:
+              - autoscaling:SuspendProcesses
+            Condition:
+              StringEquals:
+                'autoscaling:ResourceTag/aws:cloudformation:stack-id': !Ref AWS::StackId
+            Effect: Allow
+            Resource: '*'
         Version: 2012-10-17
       PolicyName: !Sub ra-rdsh-${AWS::StackName}
       Roles:


### PR DESCRIPTION
So, yeah. The rdsh still uses those permissions. Combine that with a bug in the snippet still in the cfn repo (dang it powershell, just errexit!), and got a false success when it was tested.
