### PR TITLE
Tightens grep for current_version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
       before_script:
         - |
           PRIOR_VERSION=$(git describe --abbrev=0 --tags)
-          RELEASE_VERSION=$(grep current_version $TRAVIS_BUILD_DIR/.bumpversion.cfg | sed 's/^.*= //' )
+          RELEASE_VERSION=$(grep "^current_version =" $TRAVIS_BUILD_DIR/.bumpversion.cfg | sed 's/^.*= //' )
           RELEASE_BODY="* [terraform-aws-remote-access v$RELEASE_VERSION CHANGELOG](https://github.com/plus3it/terraform-aws-remote-access/blob/$RELEASE_VERSION/CHANGELOG.md)"
           export PRIOR_VERSION RELEASE_VERSION RELEASE_BODY
       script: skip


### PR DESCRIPTION
Addresses the failure: https://travis-ci.com/github/plus3it/terraform-aws-remote-access/jobs/315377383#L206

```
$ (set -x; git tag -a $RELEASE_VERSION -m $RELEASE_VERSION)
      
++git tag -a 0.5.2 Version: '{current_version}' Version: '{current_version}' Version: '{current_version}' Version: '{current_version}' -m 0.5.2 Version: '{current_version}' Version: '{current_version}' Version: '{current_version}' Version: '{current_version}'
fatal: too many params
The command "(set -x; git tag -a $RELEASE_VERSION -m $RELEASE_VERSION)
      " failed and exited with 128 during .
```