### PR TITLE
Uses ubuntu 18.04 (bionic) with travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 
 language: node_js
 


### PR DESCRIPTION
This ensures nodejs 12 is pre-installed, dramatically improving build times.

* https://docs.travis-ci.com/user/reference/bionic/#javascript-and-nodejs-support
