### PR TITLE
Creates a local temp directory that can be used with user profile disks

### DIFF
--- a/scripts/configure-rdsh.ps1
+++ b/scripts/configure-rdsh.ps1
@@ -360,6 +360,28 @@ Write-Verbose "Installed psget"
 # Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
 # Write-Verbose "Installed nuget"
 
+# Create temp directory
+$TmpDirPath = "C:\Temp"
+$TmpDir = New-Item -Path $TmpDirPath -ItemType "Directory" -Force
+Write-Verbose "Created temp directory, ${TmpDir}"
+
+$TmpAcl = Get-Acl $TmpDir
+$TmpAcl.SetAccessRuleProtection($True, $False)
+$TmpRule = New-Object System.Security.AccessControl.FileSystemAccessRule('CREATOR OWNER', 'FullControl', 'ContainerInherit, ObjectInherit', 'InheritOnly', 'Allow')
+$TmpAcl.AddAccessRule($TmpRule)
+$TmpRule = New-Object System.Security.AccessControl.FileSystemAccessRule('SYSTEM', 'FullControl', 'ContainerInherit, ObjectInherit', 'None', 'Allow')
+$TmpAcl.AddAccessRule($TmpRule)
+$TmpRule = New-Object System.Security.AccessControl.FileSystemAccessRule('Administrators', 'FullControl', 'None', 'None', 'Allow')
+$TmpAcl.AddAccessRule($TmpRule)
+$TmpRule = New-Object System.Security.AccessControl.FileSystemAccessRule('Users', 'Read', 'None', 'None', 'Allow')
+$TmpAcl.AddAccessRule($TmpRule)
+$TmpRule = New-Object System.Security.AccessControl.FileSystemAccessRule('Users', 'Synchronize', 'None', 'None', 'Allow')
+$TmpAcl.AddAccessRule($TmpRule)
+$TmpRule = New-Object System.Security.AccessControl.FileSystemAccessRule('Users', 'AppendData', 'None', 'None', 'Allow')
+$TmpAcl.AddAccessRule($TmpRule)
+Set-Acl $TmpDirPath $TmpAcl -ErrorAction Stop
+Write-Verbose "Restricted the acl on the temp directory, ${TmpDir}"
+
 if ($HealthCheckEndPoint)
 {
     Write-Verbose "Setting up the RDSH Health Check End Point..."


### PR DESCRIPTION
This implements a local temp directory that can be used in conjunction with a GPO to create a directory per user and set the TEMP/TMP environment variables. See this blog for details:

* https://helpcenter.itopia.com/en/articles/748437-installing-chrome-extensions-for-users-with-user-profile-disks

One enhancement to the blog post, is that the "Folder" GPO item should be created in the user context and not the system context. From the item properties, select the Common tab, and check the box, "Run in logged-on user's security context (user policy option)". This way the user's folder will be owned by the user.