### PR TITLE
Removes vscode due to lack of multi-user support

### DIFF
--- a/scripts/configure-rdsh.ps1
+++ b/scripts/configure-rdsh.ps1
@@ -322,8 +322,7 @@ $ScoopPackages = @(
     "putty",
     "python",
     "shellcheck",
-    "slack",
-    "vscode"
+    "slack"
 )
 
 # Deps needed for python. Need to silence output from lessmsi since it has non-ASCII characters


### PR DESCRIPTION
When more than one user on the system attempts to open vscode, it errors with "A second instance of vscode is already running as administrator"